### PR TITLE
Evaluate JS in the global context.

### DIFF
--- a/src/remote-js.lisp
+++ b/src/remote-js.lisp
@@ -118,7 +118,7 @@ RemoteJS.connect = function() {
   var ws  = new WebSocket(\"ws://~A:~D/\");
 
   ws.onmessage = function(evt) {
-    eval(evt.data);
+    (1, eval)(evt.data);
   };
 
   ws.onopen = function() {

--- a/t/remote-js.lisp
+++ b/t/remote-js.lisp
@@ -16,8 +16,7 @@
       (setf ctx (remote-js:make-context
                  :recordp t
                  :callback #'(lambda (message)
-                               (when (string= message "test")
-                                 (setf received t))))))
+                               (setf received message)))))
     (finishes
      (remote-js:start ctx))
     (finishes
@@ -35,7 +34,13 @@
      (stringp (remote-js:eval ctx "RemoteJS.send('test')")))
     (sleep 0.1)
     (is-true
-     received)
+     (string= received "test"))
+    (finishes (remote-js:eval ctx "var test='global'"))
+    (sleep 0.1)
+    (finishes (remote-js:eval ctx "RemoteJS.send(test)"))
+    (sleep 0.1)
+    (is-true
+     (string= received "global"))
     (finishes
      (delete-file file))
     (finishes


### PR DESCRIPTION
This change makes eval to run in the global scope, and by effect allows creating new global variables and functions from the evaluated code.